### PR TITLE
Fix syntax for pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@ build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0"]
 
 [tool.poetry]
-authors = ["Clay O'Neil"]
+authors = ["Clay O'Neil <oneil512@umn.edu>"]
 description = "A debugger that can step forward AND backwards"
 readme = "README.md"
 version = "0.0.1"
 packages = [{ include = "timeless_debugger"}]
 
 [tool.poetry.dependencies]
-pydantic
-python
+pydantic = "^1.9.1"
+python = "^3.9"


### PR DESCRIPTION
The dependencies in your pyproject.toml need to have versions specified, poetry does the automatically when you run `poetry add <some_package>`. Your authors list also requires email addresses to be specified so i grabbed your public github email. Feel free to adjust as needed.